### PR TITLE
Typo for AlertIsPresent

### DIFF
--- a/src/WaitHelpers/ExpectedConditions.cs
+++ b/src/WaitHelpers/ExpectedConditions.cs
@@ -571,7 +571,7 @@ namespace SeleniumExtras.WaitHelpers
         }
 
         /// <summary>
-        /// An expectation for checking the AlterIsPresent
+        /// An expectation for checking the AlertIsPresent
         /// </summary>
         /// <returns>Alert </returns>
         public static Func<IWebDriver, IAlert> AlertIsPresent()


### PR DESCRIPTION
XML Doc typo:
1. "AlterIsPresent" to "AlertIsPresent".