### PR TITLE
this changes for to make possible to use the method ElementIfVisible(…

### DIFF
--- a/src/WaitHelpers/ExpectedConditions.cs
+++ b/src/WaitHelpers/ExpectedConditions.cs
@@ -138,6 +138,28 @@ namespace SeleniumExtras.WaitHelpers
         /// </summary>
         /// <param name="locator">The locator used to find the element.</param>
         /// <returns>The list of <see cref="IWebElement"/> once it is located and visible.</returns>
+        
+           public static Func<IWebDriver, IWebElement> ElementIsVisible(IWebElement element)
+        {
+            return (driver) =>
+                {
+                    try
+                    {
+                        return ElementIfVisible(element);
+                    }
+                    catch (StaleElementReferenceException)
+                    {
+                        return null;
+                    }
+                };
+        }
+
+        /// <summary>
+        /// An expectation for checking that all elements present on the web page that
+        /// match the element are visible. Visibility means that the elements are not
+        /// only displayed but also have a height and width that is greater than 0.
+        /// </summary>
+        /// <returns>The list of <see cref="IWebElement"/> once the element is visible.</returns>
         public static Func<IWebDriver, ReadOnlyCollection<IWebElement>> VisibilityOfAllElementsLocatedBy(By locator)
         {
             return (driver) =>


### PR DESCRIPTION
…)  with WebElement

I was using selenium java before. There is such a method in java ;

public static ExpectedCondition<WebElement> visibilityOf(final WebElement element)

I cannot find it in c#. There is such a method in C# ;

public static Func<IWebDriver, IWebElement> ElementIsVisible(By locator)

In this case, I have to give a locater to the method I created every time. However, I want a method where I can directly give the element.  The proposition is to make this possible. 

Thank you 
Best regards,