### PR TITLE
Stop ElementToBeClickable from throwing a StaleElementReferenceException

### DIFF
--- a/src/WaitHelpers/ExpectedConditions.cs
+++ b/src/WaitHelpers/ExpectedConditions.cs
@@ -432,9 +432,9 @@ namespace SeleniumExtras.WaitHelpers
         {
             return (driver) =>
             {
-                var element = ElementIfVisible(driver.FindElement(locator));
                 try
                 {
+                    var element = ElementIfVisible(driver.FindElement(locator));
                     if (element != null && element.Enabled)
                     {
                         return element;


### PR DESCRIPTION
There is an edge case where an element could become stale when the isDisplayed check is performed.  This results in ElementIfVisible throwing a StaleElementReferenceException when it should ignore them.